### PR TITLE
Generating output directories and output files for each script (xunit, logs, casper generated files, cookies) and minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ jdk: oraclejdk7
 before_install:
   - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
   - tar xvf 1.1-beta3.tar.gz
-  - export PATH=$PATH:casperjs-1.1-beta3/bin
-before_script:
+  - export PATH=$PATH:$(pwd)/casperjs-1.1-beta3/bin
   - phantomjs --version
   - casperjs --version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk: oraclejdk7
 before_install:
   - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
-  - tar xvf 1.1-beta3.tar.gz.tar.gz -C casper
+  - tar xvf 1.1-beta3.tar.gz -C casper
   - export PATH=$PATH:casper/bin
 before_script:
   - phantomjs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: java
 jdk: oraclejdk7
 before_install:
   - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
-  - tar xvf 1.1-beta3.tar.gz -C casper
-  - export PATH=$PATH:casper/bin
+  - tar xvf 1.1-beta3.tar.gz
+  - export PATH=$PATH:casperjs-1.1-beta3/bin
 before_script:
   - phantomjs --version
   - casperjs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk: oraclejdk7
 before_install:
   - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
-  - tar xvf ${CASPER_VERSION}.tar.gz -C casper
+  - tar xvf 1.1-beta3.tar.gz.tar.gz -C casper
   - export PATH=$PATH:casper/bin
 before_script:
   - phantomjs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,28 @@ language: java
 jdk: oraclejdk7
 before_install:
   - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
+  - wget https://github.com/n1k0/casperjs/archive/1.0.4.tar.gz
   - tar xvf 1.1-beta3.tar.gz
+  - tar xvf 1.0.4.tar.gz
   - export PATH=$PATH:$(pwd)/casperjs-1.1-beta3/bin
   - phantomjs --version
   - casperjs --version
+  - echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+          <toolchains>
+            <toolchain>
+              <type>casperjs</type>
+              <provides> <version>1.0.4</version> </provides>
+              <configuration> <casperjsExecutable>$(pwd)/casperjs-1.0.4/bin/casperjs</casperjsExecutable> </configuration>
+            </toolchain>
+            <toolchain>
+              <type>casperjs</type>
+              <provides> <version>1.1.0</version> </provides>
+              <configuration> <casperjsExecutable>$(pwd)/casperjs-1.1-beta3/bin/casperjs</casperjsExecutable> </configuration>
+            </toolchain>
+
+          </toolchains>" > ~/.m2/toolchains.xml
 script:
   - mvn install
-  - mvn -Pit install
+  - mvn -X -Pit install
 after_script:
   - find -name build.log -exec cat {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: java
-script: mvn $TARGET
 jdk: oraclejdk7
-env:
-  matrix:
-    - TARGET='install'
-    - TARGET='-Pit install'
+before_install:
+  - wget https://github.com/n1k0/casperjs/archive/1.1-beta3.tar.gz
+  - tar xvf ${CASPER_VERSION}.tar.gz -C casper
+  - export PATH=$PATH:casper/bin
+before_script:
+  - phantomjs --version
+  - casperjs --version
+script:
+  - mvn install
+  - mvn -Pit install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ before_install:
 script:
   - mvn install
   - mvn -Pit install
+after_script:
+  - find -name build.log -exec cat {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+script: mvn $TARGET
+jdk: oraclejdk7
+env:
+  matrix:
+    - TARGET='install'
+    - TARGET='-Pit install'

--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ If you encounter issues or think about any kind of enhancements, you can add the
 ## License
 
 This plugin is licensed with [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+## CI
+![Build Status Images](https://travis-ci.org/burgacl/casperjs-runner-maven-plugin.svg)

--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ If you encounter issues or think about any kind of enhancements, you can add the
 This plugin is licensed with [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 ## CI
-![Build Status Images](https://travis-ci.org/burgacl/casperjs-runner-maven-plugin.svg)
+[![Build Status Images](https://travis-ci.org/burgacl/casperjs-runner-maven-plugin.svg)](https://travis-ci.org/burgacl/casperjs-runner-maven-plugin)
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.linsolas</groupId>
     <artifactId>casperjs-runner-maven-plugin</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.2-20140725</version>
     <name>CasperJS runner Maven plugin</name>
     <description>Runs JavaScript and/or CoffeScript test files on CasperJS instance</description>
     <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.linsolas</groupId>
     <artifactId>casperjs-runner-maven-plugin</artifactId>
-    <version>1.0.2-20140725</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>CasperJS runner Maven plugin</name>
     <description>Runs JavaScript and/or CoffeScript test files on CasperJS instance</description>
     <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/it/casperjs-runner/execution-in-output-dir/invoker.properties
+++ b/src/it/casperjs-runner/execution-in-output-dir/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test
+invoker.failureBehavior=fail-at-end

--- a/src/it/casperjs-runner/execution-in-output-dir/pom.xml
+++ b/src/it/casperjs-runner/execution-in-output-dir/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.linsolas</groupId>
+  <artifactId>execution-in-output-dir</artifactId>
+  <version>1.0</version>
+
+  <name>CasperJS Runner :: Execution in generated output directory</name>
+
+  <url>no-url</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <casperjs.verbose>true</casperjs.verbose>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.github.linsolas</groupId>
+          <artifactId>casperjs-runner-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.linsolas</groupId>
+        <artifactId>casperjs-runner-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+		<configuration>
+			<testsDir>${project.basedir}/src/test/casperjs/testsDir</testsDir>
+		</configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/casperjs-runner/execution-in-output-dir/postbuild.groovy
+++ b/src/it/casperjs-runner/execution-in-output-dir/postbuild.groovy
@@ -1,0 +1,12 @@
+file = new File(basedir, 'build.log');
+assert file.exists();
+assert file.text.contains('casperjs-runner-maven-plugin');
+assert file.text.contains('Tests run: 2, Success: 2 Failures: 0. Time elapsed:');
+
+capture_js = new File(basedir, 'target/casperjs/testsDir/test_capture_js/test.png');
+capture_coffee = new File(basedir, 'target/casperjs/testsDir/test_capture_coffee/test.png');
+
+assert capture_js.exists();
+assert capture_coffee.exists();
+
+return true;

--- a/src/it/casperjs-runner/execution-in-output-dir/src/test/casperjs/testsDir/test_capture.coffee
+++ b/src/it/casperjs-runner/execution-in-output-dir/src/test/casperjs/testsDir/test_capture.coffee
@@ -1,0 +1,9 @@
+casper.test.begin "Fake test", 2, (test) ->
+  casper.start()
+  casper.then ->
+    test.assert true, "true is so true"
+    test.assertNot false, "false is so wrong"
+    @capture "test.png"
+
+  casper.run ->
+    test.done()

--- a/src/it/casperjs-runner/execution-in-output-dir/src/test/casperjs/testsDir/test_capture.js
+++ b/src/it/casperjs-runner/execution-in-output-dir/src/test/casperjs/testsDir/test_capture.js
@@ -1,0 +1,13 @@
+casper.test.begin('Fake test', 2, function(test) {
+  casper.start();
+
+  casper.then(function() {
+    test.assert(true, 'true is so true');
+    test.assertNot(false, 'false is so wrong');
+    this.capture('test.png');
+  });
+
+  casper.run(function() {
+    test.done();
+  });
+});

--- a/src/it/casperjs-runner/generate-cookies-file/invoker.properties
+++ b/src/it/casperjs-runner/generate-cookies-file/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test
+invoker.failureBehavior=fail-at-end

--- a/src/it/casperjs-runner/generate-cookies-file/pom.xml
+++ b/src/it/casperjs-runner/generate-cookies-file/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.linsolas</groupId>
+  <artifactId>generate-cookies-file</artifactId>
+  <version>1.0</version>
+
+  <name>CasperJS Runner :: Generate cookies file</name>
+
+  <url>no-url</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <casperjs.verbose>true</casperjs.verbose>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.github.linsolas</groupId>
+          <artifactId>casperjs-runner-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.linsolas</groupId>
+        <artifactId>casperjs-runner-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+		  <testsDir>${project.basedir}/src/test/casperjs/testsDir</testsDir>
+          <generateCookies>true</generateCookies>
+        </configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/casperjs-runner/generate-cookies-file/postbuild.groovy
+++ b/src/it/casperjs-runner/generate-cookies-file/postbuild.groovy
@@ -1,0 +1,7 @@
+test_js_cookies = new File(basedir, 'target/casperjs/testsDir/test_js/cookies_file.txt');
+test_coffee_cookies = new File(basedir, 'target/casperjs/testsDir/test_coffee/cookies_file.txt');
+
+assert test_js_cookies.exists();
+assert test_coffee_cookies.exists();
+
+return true;

--- a/src/it/casperjs-runner/generate-cookies-file/src/test/casperjs/testsDir/test.coffee
+++ b/src/it/casperjs-runner/generate-cookies-file/src/test/casperjs/testsDir/test.coffee
@@ -1,0 +1,4 @@
+casper.test.begin 'Fake test', 2, (test) ->
+  test.assert true, 'true is so true'
+  test.assertNot false, 'false is so wrong'
+  test.done()

--- a/src/it/casperjs-runner/generate-cookies-file/src/test/casperjs/testsDir/test.js
+++ b/src/it/casperjs-runner/generate-cookies-file/src/test/casperjs/testsDir/test.js
@@ -1,0 +1,5 @@
+casper.test.begin('Fake test', 2, function(test) {
+  test.assert(true, 'true is so true');
+  test.assertNot(false, 'false is so wrong');
+  test.done();
+});

--- a/src/it/casperjs-runner/generate-logs/invoker.properties
+++ b/src/it/casperjs-runner/generate-logs/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test
+invoker.failureBehavior=fail-at-end

--- a/src/it/casperjs-runner/generate-logs/pom.xml
+++ b/src/it/casperjs-runner/generate-logs/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.linsolas</groupId>
+  <artifactId>generate-logs</artifactId>
+  <version>1.0</version>
+
+  <name>CasperJS Runner :: Generate logs</name>
+
+  <url>no-url</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <casperjs.verbose>true</casperjs.verbose>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.github.linsolas</groupId>
+          <artifactId>casperjs-runner-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.linsolas</groupId>
+        <artifactId>casperjs-runner-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+		  <testsDir>${project.basedir}/src/test/casperjs/testsDir</testsDir>
+          <generateLogs>true</generateLogs>
+        </configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/casperjs-runner/generate-logs/postbuild.groovy
+++ b/src/it/casperjs-runner/generate-logs/postbuild.groovy
@@ -1,0 +1,27 @@
+file = new File(basedir, 'build.log');
+test_js_log = new File(basedir, 'target/casperjs/testsDir/test_js/build.log');
+test_coffee_log = new File(basedir, 'target/casperjs/testsDir/test_coffee/build.log');
+
+assert file.exists();
+assert file.text.contains('casperjs-runner-maven-plugin');
+assert file.text.contains('Execution of test test.js');
+assert file.text.contains('Execution of test test.coffee');
+assert file.text.contains('PASS 2 tests executed');
+assert file.text.contains('2 passed, 0 failed');
+assert file.text.contains('Tests run: 2, Success: 2 Failures: 0. Time elapsed:');
+
+assert test_js_log.exists();
+assert test_js_log.text.contains('[casperjs --verbose');
+assert test_js_log.text.contains('test');
+assert test_js_log.text.contains('# Fake test from generate-logs/.../test.js');
+assert test_js_log.text.contains('PASS 2 tests executed');
+assert test_js_log.text.contains('2 passed, 0 failed');
+
+assert test_coffee_log.exists();
+assert test_coffee_log.text.contains('[casperjs --verbose');
+assert test_coffee_log.text.contains('test');
+assert test_coffee_log.text.contains('# Fake test from generate-logs/.../test.coffee');
+assert test_coffee_log.text.contains('PASS 2 tests executed');
+assert test_coffee_log.text.contains('2 passed, 0 failed');
+
+return true;

--- a/src/it/casperjs-runner/generate-logs/src/test/casperjs/testsDir/test.coffee
+++ b/src/it/casperjs-runner/generate-logs/src/test/casperjs/testsDir/test.coffee
@@ -1,0 +1,4 @@
+casper.test.begin 'Fake test from generate-logs/.../test.coffee', 2, (test) ->
+  test.assert true, 'true is so true'
+  test.assertNot false, 'false is so wrong'
+  test.done()

--- a/src/it/casperjs-runner/generate-logs/src/test/casperjs/testsDir/test.js
+++ b/src/it/casperjs-runner/generate-logs/src/test/casperjs/testsDir/test.js
@@ -1,0 +1,13 @@
+casper.test.begin('Fake test from generate-logs/.../test.js', 2, function(test) {
+  casper.start('http://www.google.com');
+
+  casper.then(function() {
+    test.assert(true, 'true is so true');
+    test.assertNot(false, 'false is so wrong');
+	this.capture('test.png');
+  });
+
+  casper.run(function() {
+    test.done();
+  });
+});

--- a/src/it/casperjs-runner/generating-output-dir/invoker.properties
+++ b/src/it/casperjs-runner/generating-output-dir/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean test
+invoker.failureBehavior=fail-at-end

--- a/src/it/casperjs-runner/generating-output-dir/pom.xml
+++ b/src/it/casperjs-runner/generating-output-dir/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.github.linsolas</groupId>
+  <artifactId>generating-output-dir</artifactId>
+  <version>1.0</version>
+
+  <name>CasperJS Runner :: script output directory</name>
+
+  <url>no-url</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <casperjs.verbose>true</casperjs.verbose>
+  </properties>
+
+  <build>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.github.linsolas</groupId>
+          <artifactId>casperjs-runner-maven-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>com.github.linsolas</groupId>
+        <artifactId>casperjs-runner-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+		<configuration>
+			<testsDir>${project.basedir}/src/test/casperjs/testsDir</testsDir>
+		</configuration>
+      </plugin>
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/it/casperjs-runner/generating-output-dir/postbuild.groovy
+++ b/src/it/casperjs-runner/generating-output-dir/postbuild.groovy
@@ -1,0 +1,11 @@
+file = new File(basedir, 'build.log');
+assert file.exists();
+assert file.text.contains('casperjs-runner-maven-plugin');
+assert file.text.contains('Tests run: 4, Success: 4 Failures: 0. Time elapsed:');
+
+assert new File(basedir, 'target/casperjs/testsDir/test_js').isDirectory();
+assert new File(basedir, 'target/casperjs/testsDir/test_coffee').isDirectory();
+assert new File(basedir, 'target/casperjs/testsDir/test_test_js').isDirectory();
+assert new File(basedir, 'target/casperjs/testsDir/subdir/test_js').isDirectory();
+
+return true;

--- a/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/subdir/test.js
+++ b/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/subdir/test.js
@@ -1,0 +1,5 @@
+casper.test.begin('Fake test', 2, function(test) {
+  test.assert(true, 'true is so true');
+  test.assertNot(false, 'false is so wrong');
+  test.done();
+});

--- a/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.coffee
+++ b/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.coffee
@@ -1,0 +1,4 @@
+casper.test.begin 'Fake test', 2, (test) ->
+  test.assert true, 'true is so true'
+  test.assertNot false, 'false is so wrong'
+  test.done()

--- a/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.js
+++ b/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.js
@@ -1,0 +1,5 @@
+casper.test.begin('Fake test', 2, function(test) {
+  test.assert(true, 'true is so true');
+  test.assertNot(false, 'false is so wrong');
+  test.done();
+});

--- a/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.test.js
+++ b/src/it/casperjs-runner/generating-output-dir/src/test/casperjs/testsDir/test.test.js
@@ -1,0 +1,13 @@
+casper.test.begin('Generating capture', 2, function(test) {
+  casper.start();
+
+  casper.then(function() {
+    test.assert(true, 'true is so true');
+	test.assertNot(false, 'false is so wrong');
+	this.capture('test.png');
+  });
+
+  casper.run(function() {
+    test.done();
+  });
+});

--- a/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
+++ b/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
@@ -214,6 +214,10 @@ public class CasperJSRunnerMojo extends AbstractMojo {
      * CasperJS 1.1 and above<br/>Set the for the CasperJS option <code>--engine=[engine]</code>: will change the rendering engine
      * (phantomjs or slimerjs)
      */
+
+    @Parameter(property = "casperjs.ignoreSslErrors", defaultValue = "false")
+    private boolean ignoreSslErrors;
+
     @Parameter(property = "casperjs.engine")
     private String engine;
 
@@ -413,6 +417,10 @@ public class CasperJSRunnerMojo extends AbstractMojo {
         // Option --verbose, to output log messages to the console
         if (casperVerbose) {
             cmdLine.addArgument("--verbose");
+        }
+        // Option --ignore-ssl-errors
+        if(ignoreSslErrors) {
+            cmdLine.addArgument("--ignore-ssl-errors=true");
         }
         // Option --engine, to select phantomJS or slimerJS engine
         if (StringUtils.isNotBlank(engine)) {

--- a/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
+++ b/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
@@ -72,19 +72,19 @@ public class CasperJSRunnerMojo extends AbstractMojo {
     private String test;
 
     /**
-     * A list of <code>&lt;testInclude&gt;</code> elements specifying the tests (by pattern) that should be included in testing.
+     * A list of <code>&lt;testsInclude&gt;</code> elements specifying the tests (by pattern) that should be included in testing.
      * <br/><b>Default value:</b> When not specified and when the test parameter is not specified, the default includes will be
      * (javascript patterns will only be set if <code>includeJS</code> is <code>true</code>, and coffee patterns will only be set
      * if <code>includeCS</code> is <code>true</code>)
 <br/><br/>
-<code>&lt;testIncludes&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;Test*.js&lt;/testInclude&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;*Test.js&lt;/testInclude&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;*TestCase.js&lt;/testInclude&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;Test*.coffee&lt;/testInclude&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;*Test.coffee&lt;/testInclude&gt;<br/>
-&nbsp;&nbsp;&lt;testInclude&gt;**&#47;*TestCase.coffee&lt;/testInclude&gt;<br/>
-&lt;/testIncludes&gt;</code>
+<code>&lt;testsIncludes&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;Test*.js&lt;/testsInclude&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;*Test.js&lt;/testsInclude&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;*TestCase.js&lt;/testsInclude&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;Test*.coffee&lt;/testsInclude&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;*Test.coffee&lt;/testsInclude&gt;<br/>
+&nbsp;&nbsp;&lt;testsInclude&gt;**&#47;*TestCase.coffee&lt;/testsInclude&gt;<br/>
+&lt;/testsIncludes&gt;</code>
      */
     @Parameter
     private List<String> testsIncludes;

--- a/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
+++ b/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
@@ -363,7 +363,7 @@ public class CasperJSRunnerMojo extends AbstractMojo {
         }
         // Option --xunit, to export results in XML file
         if (enableXmlReport) {
-            cmdLine.addArgument("--xunit=" + new File(targetDir, "TEST-"+f.getName().replaceAll("\\.", "_") + ".xml"));
+            cmdLine.addArgument("--xunit=results.xml");
         }
         // Option --fast-fast, to terminate the test suite once a failure is
         // found

--- a/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
+++ b/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
@@ -194,8 +194,15 @@ public class CasperJSRunnerMojo extends AbstractMojo {
     /**
      * Set the value for the CasperJS option --direct: will output log messages directly to the console.
      */
+    @Deprecated
     @Parameter(property = "casperjs.direct", defaultValue = "false")
     private boolean direct;
+
+    /**
+     * Set the value for the CasperJS option --verbose: will output log messages directly to the console.
+     */
+    @Parameter(property = "casperjs.casper.verbose", defaultValue = "false")
+    private boolean casperVerbose;
 
     /**
      * Set the value for the CasperJS option --fail-fast: will terminate the current test suite as soon as a first failure is encountered.
@@ -402,6 +409,10 @@ public class CasperJSRunnerMojo extends AbstractMojo {
         // Option --direct, to output log messages to the console
         if (direct) {
             cmdLine.addArgument("--direct");
+        }
+        // Option --verbose, to output log messages to the console
+        if (casperVerbose) {
+            cmdLine.addArgument("--verbose");
         }
         // Option --engine, to select phantomJS or slimerJS engine
         if (StringUtils.isNotBlank(engine)) {

--- a/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
+++ b/src/main/java/com/github/linsolas/casperjsrunner/CasperJSRunnerMojo.java
@@ -218,6 +218,9 @@ public class CasperJSRunnerMojo extends AbstractMojo {
     @Parameter(property = "casperjs.ignoreSslErrors", defaultValue = "false")
     private boolean ignoreSslErrors;
 
+    @Parameter(property = "casperjs.proxyAuth")
+    private String proxyAuth;
+
     @Parameter(property = "casperjs.engine")
     private String engine;
 
@@ -421,6 +424,10 @@ public class CasperJSRunnerMojo extends AbstractMojo {
         // Option --ignore-ssl-errors
         if(ignoreSslErrors) {
             cmdLine.addArgument("--ignore-ssl-errors=true");
+        }
+        // Option --proxy-auth
+        if(StringUtils.isNotBlank(proxyAuth)) {
+            cmdLine.addArgument("--proxy-auth=" + proxyAuth);
         }
         // Option --engine, to select phantomJS or slimerJS engine
         if (StringUtils.isNotBlank(engine)) {


### PR DESCRIPTION
Generating output directories in target/casperjs for each script and executing each script in the created directory so that casperjs generated files (such as captures) are saved in the correct directory instead of in the  project basedir.
Xunit files are all named "results.xml" and are now saved in each script output directory.
Added the possibility to generate a log file for each script which contains the command line used and casperjs console output, saved in script output directories.
Added the possibility to save the cookies generated with the script execution and to make the scripts run with a preconfigured cookies file (option --cookies-file).
Changed --direct option (which is deprecated) to --verbose.
Added --ignore-ssl-errors and --proxy-auth options. 
Fixed comments about how to use <testsIncludes> parameter.

I am merging my commits in emergency (end of internship) and integration tests are missing, I will add them by the next week
