### PR TITLE
Add the toolchain plugin to it profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,19 @@
             <build>
                 <plugins>
                     <plugin>
+                        <artifactId>maven-toolchains-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals><goal>toolchain</goal></goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <toolchains />
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
                         <version>1.9</version>
                         <configuration>


### PR DESCRIPTION
so that it is locally downloaded from central and then available for integration tests which only use the
local repository
